### PR TITLE
Update the setting for publish docker image

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,7 +1,8 @@
 name: Publish Docker Image on Tag
 on:
   push:
-    tags: '*'
+    tags:
+    - '*'
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Got the answer from https://github.community/t5/GitHub-Actions/How-to-run-GitHub-Actions-Workflow-only-for-new-tags/td-p/29413