### PR TITLE
Use no-cache header to make client verify with server before using cached index.html

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ func main() {
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Tells the browser to check with server before using its cached version
+		w.Header().Set("Cache-Control", "no-cache, must-revalidate")
 		http.ServeFile(w, r, "static/index.html")
 	})
 


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/1204

### Background
Some users report that they don't see the "latest" SOP version at sop.oncokb.org unless they go incognito or clear browser cache. It is likely that the browser is still using a stale cached version of index.html even after we've made a new deployment version. 
See heuristic caching https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#heuristic_caching.

### Changes
Add `no-cache` Cache-Control header. It means that the browser will always reach out to the server to check if the content has changed. It is still allowed to cache index.html, but just has to verify each time.

